### PR TITLE
Allow navigation on mobile devices

### DIFF
--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -998,9 +998,6 @@ a.fn-item.active {
       ========================================================================== */
 
 @media only screen and (max-width: 500px) {
-  .fixed-nav {
-    display: none;
-  }
   .post-holder {
     padding-top: 20px;
   }
@@ -1102,6 +1099,16 @@ a.fn-item.active {
   .site-footer {
     /*margin-top: 0.8rem;*/
     font-size: 1.1rem;
+  }
+}
+
+/*
+  Allow navigation on mobile devices (most devices announce ~ 410-490px width).
+  So only drop navigation if really needed for extemly small devices
+*/
+@media only screen and (max-width: 399px) {
+  .fixed-nav {
+    display: none;
   }
 }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -76,7 +76,7 @@ var $sitehead = $("#site-head");
 
         if (w >= Math.floor(g) && w <= Math.ceil(h)) {
           $(".fixed-nav").fadeOut("fast");
-        } else if ($(window).width() > 500) {
+        } else if ($(window).width() > 399) {
           $(".fixed-nav").fadeIn("fast");
         }
 


### PR DESCRIPTION
Fixes: #90

Most smartphones announce a width of about 410 to 490px.
So also show the navigation on those devices and only only drop navigation if really needed for extremely small devices.