### PR TITLE
Enable inverting homepage section styling

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -356,13 +356,13 @@ table table table {
   background-color: #fff;
 }
 
-table tbody > tr:nth-child(odd) > td,
-table tbody > tr:nth-child(odd) > th {
+table tbody > tr:nth-child(dark) > td,
+table tbody > tr:nth-child(dark) > th {
   background-color: #f6f6f6;
 }
 
-table.plain tbody > tr:nth-child(odd) > td,
-table.plain tbody > tr:nth-child(odd) > th {
+table.plain tbody > tr:nth-child(dark) > td,
+table.plain tbody > tr:nth-child(dark) > th {
     background: transparent;
 }
 
@@ -466,7 +466,7 @@ li {
   background: #f2efe8;
   position: relative;
 }
-.post-holder.odd {
+.post-holder.dark {
   background: #b80135;
   color: white;
 }
@@ -528,7 +528,7 @@ a.fn-item.active {
   border-top: 50px solid #f2efe8;
   border-radius: 25px;
 }
-.post-after.even {
+.post-after.light {
   left: 6%;
 }
 

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -356,13 +356,13 @@ table table table {
   background-color: #fff;
 }
 
-table tbody > tr:nth-child(dark) > td,
-table tbody > tr:nth-child(dark) > th {
+table tbody > tr:nth-child(odd) > td,
+table tbody > tr:nth-child(odd) > th {
   background-color: #f6f6f6;
 }
 
-table.plain tbody > tr:nth-child(dark) > td,
-table.plain tbody > tr:nth-child(dark) > th {
+table.plain tbody > tr:nth-child(odd) > td,
+table.plain tbody > tr:nth-child(odd) > th {
     background: transparent;
 }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -28,17 +28,9 @@ var $sitehead = $("#site-head");
     }
   }
   $(document).ready(function () {
-    $postholder.each(function (e) {
-      if (e % 2 != 0) $(this).addClass("odd");
-    });
-
     $postafter.each(function (e) {
       var bg = $(this).parent().css("background-color");
       $(this).css("border-top-color", bg);
-
-      if (e % 2 == 0) {
-        $(this).addClass("even");
-      }
     });
 
     $("a.btn.site-menu").click(function (e) {

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -46,7 +46,7 @@ title = "Jane Doe - Nutrition Coach & Chef Consultant"
     hidedesignbyline = false
 
     # The sections of the home page alternate styling. Mark invert as true to swap the styling of the sections
-    invert = false
+    invertSectionColors = false
     
     [params.meta]
         keywords = "some, keywords, for, seo, you, know, google, duckduckgo, and, such"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -44,6 +44,9 @@ title = "Jane Doe - Nutrition Coach & Chef Consultant"
     # This theme will, by default, inject a design-by-line at the bottom of the page.
     # You can turn it off, but we would really appreciate if you don’t :-)
     hidedesignbyline = false
+
+    # The sections of the home page alternate styling. Mark invert as true to swap the styling of the sections
+    invert = false
     
     [params.meta]
         keywords = "some, keywords, for, seo, you, know, google, duckduckgo, and, such"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,7 +28,7 @@
     <div class='fixed-nav'>
     </div>
     {{ range $index_val, $elem_val := $filtered }}
-        <div class='post-holder{{ if and (ne .Site.Params.invert true) (not (modBool $index_val 2)) }} odd{{ else if and (eq .Site.Params.invert true) (modBool $index_val 2) }} odd{{ end }}'>
+        <div class='post-holder{{ if and (ne .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} odd{{ else if and (eq .Site.Params.invertSectionColors true) (modBool $index_val 2) }} odd{{ end }}'>
             <article id='{{ anchorize .Title }}' class='post {{ if eq $index_val 0 }}first{{ end }} {{ if eq (add $index_val 1) (len $sections) }}last{{ end }}'>
                 <header class="post-header">
                     <h2 class="post-title">{{ .Title | safeHTML }}</h2>
@@ -37,7 +37,7 @@
                     {{ .Content }}
                 </section>
             </article>
-            <div class='post-after{{ if and (ne .Site.Params.invert true) (modBool $index_val 2) }} even{{ else if and (eq .Site.Params.invert true) (not (modBool $index_val 2)) }} even{{ end }}'></div>
+            <div class='post-after{{ if and (ne .Site.Params.invertSectionColors true) (modBool $index_val 2) }} even{{ else if and (eq .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} even{{ end }}'></div>
         </div>
     {{ end }}
 </main>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,7 +28,7 @@
     <div class='fixed-nav'>
     </div>
     {{ range $index_val, $elem_val := $filtered }}
-        <div class='post-holder'>
+        <div class='post-holder{{ if and (ne .Site.Params.invert true) (not (modBool $index_val 2)) }} odd{{ else if and (eq .Site.Params.invert true) (modBool $index_val 2) }} odd{{ end }}'>
             <article id='{{ anchorize .Title }}' class='post {{ if eq $index_val 0 }}first{{ end }} {{ if eq (add $index_val 1) (len $sections) }}last{{ end }}'>
                 <header class="post-header">
                     <h2 class="post-title">{{ .Title | safeHTML }}</h2>
@@ -37,7 +37,7 @@
                     {{ .Content }}
                 </section>
             </article>
-            <div class='post-after'></div>
+            <div class='post-after{{ if and (ne .Site.Params.invert true) (modBool $index_val 2) }} even{{ else if and (eq .Site.Params.invert true) (not (modBool $index_val 2)) }} even{{ end }}'></div>
         </div>
     {{ end }}
 </main>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,7 +28,7 @@
     <div class='fixed-nav'>
     </div>
     {{ range $index_val, $elem_val := $filtered }}
-        <div class='post-holder{{ if and (ne .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} odd{{ else if and (eq .Site.Params.invertSectionColors true) (modBool $index_val 2) }} odd{{ end }}'>
+        <div class='post-holder{{ if and (ne .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} dark{{ else if and (eq .Site.Params.invertSectionColors true) (modBool $index_val 2) }} dark{{ end }}'>
             <article id='{{ anchorize .Title }}' class='post {{ if eq $index_val 0 }}first{{ end }} {{ if eq (add $index_val 1) (len $sections) }}last{{ end }}'>
                 <header class="post-header">
                     <h2 class="post-title">{{ .Title | safeHTML }}</h2>
@@ -37,7 +37,7 @@
                     {{ .Content }}
                 </section>
             </article>
-            <div class='post-after{{ if and (ne .Site.Params.invertSectionColors true) (modBool $index_val 2) }} even{{ else if and (eq .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} even{{ end }}'></div>
+            <div class='post-after{{ if and (ne .Site.Params.invertSectionColors true) (modBool $index_val 2) }} light{{ else if and (eq .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} light{{ end }}'></div>
         </div>
     {{ end }}
 </main>


### PR DESCRIPTION
Add invert Param to the config file. Add the 'odd' class to the post-holders and the 'even' class to the post-afters using Hugo IF statements instead of using JS. Marking invert = true in the config file flips which sections are marked odd and even.

Addresses #107.