### PR TITLE
Correct external link to lead to project itself

### DIFF
--- a/exampleSite/content/homepage/external.md
+++ b/exampleSite/content/homepage/external.md
@@ -2,5 +2,5 @@
 title: "GitHub"
 weight: 99
 header_menu: true
-external: https://github.com/
+external: https://github.com/zjedi/hugo-scroll
 ---


### PR DESCRIPTION
If one hits the button it should help you to find the project itself, instead of linking to GH base page.