### PR TITLE
#126: Provide option to show GitInfo in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For live demo of master branch, please visit https://zjedi.github.io/hugo-scroll
 As a fallback, see a screenshot which may be a bit outdated: ![Screenshot Hugo Scroll Theme](https://raw.githubusercontent.com/zjedi/hugo-scroll/master/images/tn.png)
 
 ## Installation
-If you already have a hugo site on your machine, you can simply add this theme via
+If you already have a Hugo site on your machine, you can simply add this theme via
 ```
 git submodule add https://github.com/zjedi/hugo-scroll.git themes/hugo-scroll
 ```
@@ -24,7 +24,7 @@ For more information, read the official [Hugo setup guide][hugo-setup-guide].
 
 If you are starting fresh, simply copy over the contents of the `exampleSite`-directory included in this theme to your source directory. That should give you a good idea about how things work, and then you can go on from there to make the site your own.
 
-Please check out the [config.toml](https://github.com/zjedi/hugo-scroll/blob/master/exampleSite/config.toml) included on the [exampleSite](https://github.com/zjedi/hugo-scroll/tree/master/exampleSite) of this theme.
+Please check out the [config.toml](https://github.com/zjedi/hugo-scroll/blob/master/exampleSite/config.toml) included in the [exampleSite](https://github.com/zjedi/hugo-scroll/tree/master/exampleSite) of this theme.
 
 You can add **a new section to the homepage** by running `hugo new homepage/my-new-content.md` (or craft the file manually)
 
@@ -36,14 +36,16 @@ This theme includes the full set of [Fork Awesome 1.2.0 Icons][fork-awesome-icon
 ```markdown
 Look at this nice »envelope«-icon: `{{<icon class="fa fa-envelope">}}`. I took this from https://forkaweso.me/Fork-Awesome/icon/envelope/ :-)
 ```
-
 ### Header logo
 Configured in `_index.md`, see `exampleSite`: `header_logo: "images/chef-hat.png"`
 
-### External links
-You can add external link in the menu, see `external.md` in the `exampleSite`.
+### Footer version information
+In order to see technical version information (extracted from Hugo's [GitInfo](https://gohugo.com.cn/variables/git/)) set the following general option in your config.toml: `enableGitInfo = true`
 
-You can also use `extlink` shortcode to create a link opening in new tab:
+### External links
+You can add external links in the menu, see `external.md` in the `exampleSite`.
+
+You can also use `extlink` shortcode to create a link opening in a new tab:
 ```markdown
 Visit as at {{<extlink text="Instagram" href="https://www.instagram.com/yourInstagramName/">}}
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Look at this nice »envelope«-icon: `{{<icon class="fa fa-envelope">}}`. I took
 Configured in `_index.md`, see `exampleSite`: `header_logo: "images/chef-hat.png"`
 
 ### Footer version information
-In order to see technical version information (extracted from Hugo's [GitInfo](https://gohugo.com.cn/variables/git/)) set the following general option in your config.toml: `enableGitInfo = true`
+In order to see technical version information (extracted from Hugo's [GitInfo](https://gohugo.io/variables/git/))) set the following general option in your config.toml: `enableGitInfo = true`
 
 ### External links
 You can add external links in the menu, see `external.md` in the `exampleSite`.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,6 +11,9 @@ theme = "hugo-scroll"
 # The browser tab name
 title = "Jane Doe - Nutrition Coach & Chef Consultant"
 
+# In order to add version information in the page's footer set to true.
+# enableGitInfo = true
+
 # Theme-specific variables `.Site.Params.myParamName`
 [params]
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,13 +4,10 @@
       <section class="copyright">{{ . | safeHTML }}</section>
     {{ end }}
 
-    <section>{{ echoParam .Site.Params "hidebyline" }}</section>
-
     {{ if ne .Site.Params.hidedesignbyline true }}
       <section>
         <a href="https://themes.gohugo.io/hugo-scroll/" target="_blank" rel="noopener">Hugo Scroll</a> template
       </section>
     {{ end }}
-
   </div>
 </footer>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,5 +9,13 @@
         <a href="https://themes.gohugo.io/hugo-scroll/" target="_blank" rel="noopener">Hugo Scroll</a> template
       </section>
     {{ end }}
+
+    {{ if ne .Params.enableGitInfo false }}
+      {{- if $.GitInfo -}}
+      <section>
+       version: {{ .Lastmod.Format "2006-01-02" }} | #{{ .GitInfo.AbbreviatedHash }}
+      </section>
+      {{- end -}}
+    {{ end }}
   </div>
 </footer>


### PR DESCRIPTION
Shows version information in the page's footer if configuration option 
`enableGitInfo` is set to `true`