### PR TITLE
Fix blog-logo CSS selector in responsiveness.scss

### DIFF
--- a/assets/css/responsiveness.scss
+++ b/assets/css/responsiveness.scss
@@ -93,7 +93,7 @@
     padding-top: 20px;
   }
 
-  #blog-logo img{
+  #blog-logo {
     max-height: 80px;
   }
 


### PR DESCRIPTION
Firstly, thank you very much for your work on this theme.

I have noticed that the blog logo is not scaled on smaller screens. It seems that the CSS-selector `#block-logo img` does not work, because the Element with the ID `block-logo` already is an img-Element and therefore is not referenced. This fix removes the `img` from the CSS-selector.

### Before 
![blog-logo-mobile-before](https://github.com/zjedi/hugo-scroll/assets/45793377/571d14de-d75e-4981-b8d6-67d4154abbc7)
### After
![blog-logo-mobile-after](https://github.com/zjedi/hugo-scroll/assets/45793377/36aa9206-6ed6-4646-9e25-174fb1fc03fe)

