### PR TITLE
add option to add links to the footer of the page

### DIFF
--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -274,7 +274,7 @@ a.fn-item {
   color: var(--sticky-menu-text-color);
 }
 
-/* Bottom Icons */
+/* Footer Icons */
 .icons {
   ol {
     padding-left: 0;
@@ -282,5 +282,20 @@ a.fn-item {
 
   li {
     display: inline-block;
+  }
+}
+
+/* Footer Links */
+.site-footer .links {
+  text-align: center;
+
+  ol {
+    list-style-type: none;
+    list-style-position: inside;
+    padding-left: 0;
+  }
+
+  li {
+    margin-left: unset;
   }
 }

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -55,6 +55,9 @@ title = "Jane Doe - Nutrition Coach & Chef Consultant"
     # Show contact icons for email/phone (if specified) in the footer of the page
     showContactIcons = false
 
+    # Show links indicated with footer_menu and footer_menu_title in the footer of the page
+    showFooterLinks = false
+
     [params.meta]
         keywords = "some, keywords, for, seo, you, know, google, duckduckgo, and, such"
 

--- a/exampleSite/content/homepage/license.md
+++ b/exampleSite/content/homepage/license.md
@@ -1,0 +1,7 @@
+---
+footer_menu_title: License
+footer_menu: true
+detailed_page_path: /license/
+detailed_page_homepage_content: false
+weight: 91
+---

--- a/exampleSite/content/license.md
+++ b/exampleSite/content/license.md
@@ -1,0 +1,24 @@
+---
+title: Hugo Scroll License
+---
+
+The MIT License (MIT)
+
+Copyright (c) 2020 Jan Raasch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,22 @@
+{{ $headless := .Site.GetPage "/homepage" }}
+{{ $sections := $headless.Resources.ByType "page" }}
+{{ $sections := cond .Site.BuildDrafts $sections (where $sections "Draft" "==" false) }}
+
 <footer class="site-footer">
   <div class="inner">
+    {{ if ne .Site.Params.footer.showFooterLinks false }}
+    <section class="links">
+      <ol>
+      {{ range where $sections ".Params.footer_menu" "eq" true }}
+        <li>
+          <a href="{{ .Params.detailed_page_path }}">{{ .Params.footer_menu_title }}</a>
+        </li>
+      {{ end }}
+      </ol>
+    </section>
+    <hr />
+    {{ end }}
+
     {{ if ne .Site.Params.footer.showContactIcons false }}
       {{ with .Site.Params.contact }}
       <section class="icons">


### PR DESCRIPTION
![grafik](https://github.com/zjedi/hugo-scroll/assets/1346979/8e9d5f94-7807-43a1-bf6f-32cb9507bbe6)

The header menu might get a bit busy for pages with a lot of sections and links. So I thought it would be nice to add e.g. less important links to sub-pages you might be legally required to have, like license, imprint, copyright, etc. to the footer of the page.