### PR TITLE
Handle website contacts dynamically

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -61,6 +61,14 @@ title = "Jane Doe - Nutrition Coach & Chef Consultant"
     [params.meta]
         keywords = "some, keywords, for, seo, you, know, google, duckduckgo, and, such"
 
-    [params.contact]
-        email = "mail@janedoe.com"
-        phone = "+49 1111 555555"
+    [[params.contacts]]
+        label = "phone"
+        value = "+49 1111 555555"
+        url = "tel: +49 1111 555555"
+        icon = "fa fa-phone"
+
+    [[params.contacts]]
+        label = "email"
+        value = "mail@janedoe.com"
+        url = "mailto: mail@janedoe.com"
+        icon = "fa fa-envelope"

--- a/exampleSite/content/homepage/contact.md
+++ b/exampleSite/content/homepage/contact.md
@@ -4,8 +4,6 @@ weight: 4
 header_menu: true
 ---
 
-{{<icon class="fa fa-envelope">}}&nbsp;[{{<email>}}](mailto:{{<email>}})
-
-{{<icon class="fa fa-phone">}}&nbsp;[{{<phone>}}](tel:{{<phone>}})
+{{<contact_list>}}
 
 Let us get in touch!

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,14 +18,15 @@
     {{ end }}
 
     {{ if ne .Site.Params.footer.showContactIcons false }}
-      {{ with .Site.Params.contact }}
       <section class="icons">
         <ol>
-          <li><a href="mailto:{{ .email }}" aria-label='{{ i18n "email" }}'><i class="fa fa-envelope"></i></a></li>
-          <li><a href="tel:{{ .phone }}" aria-label='{{ i18n "phone" }}'><i class="fa fa-phone"></i></a></li>
+          {{ range .Site.Params.contacts }}
+            <li>
+              <a href="{{ .url }}" aria-label='{{ i18n "{{ .label }}" }}'><i class="{{ .icon }}"></i></a>
+            </li>
+          {{ end }}
         </ol>
       </section>
-      {{ end }}
     {{ end }}
 
     {{ with .Site.Params.copyright }}

--- a/layouts/shortcodes/contact_list.html
+++ b/layouts/shortcodes/contact_list.html
@@ -1,0 +1,3 @@
+{{ range .Site.Params.contacts }}
+    <p><i class="{{ .icon}}"></i>&nbsp;<a href="{{ .url }}">{{ .value }}</a></p>
+{{ end }}


### PR DESCRIPTION
Hi! 

This commits change the way contacts params are handled: instead of declaring them statically, they are declared as an array of tables in the TOML configuration file, then they are displayed in the two sections (homepage and footer) of the website through the {{ range }} statement.

This makes handling multiple contacts params easier and avoids the need of changing manually this two files:
- `layouts/partials/footer.html`;
- `exampleSite/content/homepage/contact.md`;

Of course this results in a breaking change for the template.

I think this new mechanism could be helpful when you need to add multiple contact options to the template.