### PR TITLE
Center contact icons in the footer

### DIFF
--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -276,13 +276,10 @@ a.fn-item {
 
 /* Footer Icons */
 .icons {
-  ol {
-    padding-left: 0;
-  }
-
-  li {
-    display: inline-block;
-  }
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  padding: 8px;
 }
 
 /* Footer Links */

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,13 +19,9 @@
 
     {{ if ne .Site.Params.footer.showContactIcons false }}
       <section class="icons">
-        <ol>
-          {{ range .Site.Params.contacts }}
-            <li>
-              <a href="{{ .url }}" aria-label='{{ i18n "{{ .label }}" }}'><i class="{{ .icon }}"></i></a>
-            </li>
-          {{ end }}
-        </ol>
+        {{ range .Site.Params.contacts }}
+          <a href="{{ .url }}" aria-label='{{ i18n "{{ .label }}" }}'><i class="{{ .icon }}"></i></a>
+        {{ end }}
       </section>
     {{ end }}
 


### PR DESCRIPTION
This commit changes the way contact icons are displayed in the footer: instead of using `<li>` tags which inherit a 30px left margin, they are now just simple `<a>` tags handled by flex to center them.

The new style rules are added to the `.icons` class in `assets/css/theme.scss`.

See #171 for context.