### PR TITLE
Fix #173: `tel:` link is now handled correctly by Hugo

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -64,11 +64,18 @@ title = "Jane Doe - Nutrition Coach & Chef Consultant"
     [[params.contacts]]
         label = "phone"
         value = "+49 1111 555555"
-        url = "tel: +49 1111 555555"
+        url = "tel:+49 1111 555555"
         icon = "fa fa-phone"
 
     [[params.contacts]]
         label = "email"
         value = "mail@janedoe.com"
-        url = "mailto: mail@janedoe.com"
+        url = "mailto:mail@janedoe.com"
         icon = "fa fa-envelope"
+
+    # Add additional contacts here!
+    # [[params.contacts]]
+    #     label = ""
+    #     value = ""
+    #     url = ""
+    #     icon = ""

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,7 +20,7 @@
     {{ if ne .Site.Params.footer.showContactIcons false }}
       <section class="icons">
         {{ range .Site.Params.contacts }}
-          <a href="{{ .url }}" aria-label='{{ i18n "{{ .label }}" }}'><i class="{{ .icon }}"></i></a>
+          <a href="{{ .url | safeURL }}" aria-label='{{ i18n "{{ .label }}" }}'><i class="{{ .icon }}"></i></a>
         {{ end }}
       </section>
     {{ end }}


### PR DESCRIPTION
The `safeURL` function is required to insert URLs that are different than `http:`, `https:` and `mailto:` (e.g. `tel:`) through the Hugo templating system.

Additionally, an example about how to add new contacts is added in the `config.toml` of `exampleSite`.