### PR TITLE
Fix #173: handle `tel:` link correctly also in contact section

### DIFF
--- a/layouts/shortcodes/contact_list.html
+++ b/layouts/shortcodes/contact_list.html
@@ -1,3 +1,3 @@
 {{ range .Site.Params.contacts }}
-    <p><i class="{{ .icon}}"></i>&nbsp;<a href="{{ .url }}">{{ .value }}</a></p>
+    <p><i class="{{ .icon }}"></i>&nbsp;<a href="{{ .url | safeURL }}">{{ .value }}</a></p>
 {{ end }}


### PR DESCRIPTION
Solves the issue for contact section combined with #174.

Sorry for the mess, I was in a hurry to solve the bug.