### PR TITLE
Add support to markdown emojis

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,6 +14,9 @@ title = "Jane Doe - Nutrition Coach & Chef Consultant"
 # In order to add version information in the page's footer set to true.
 # enableGitInfo = true
 
+# enable emoji processing in Markdown (valid only for pure markdown content)
+enableEmoji = true
+
 # Theme-specific variables `.Site.Params.myParamName`
 [params]
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -110,7 +110,7 @@
         <div class='post-holder{{ if and (ne .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} dark{{ else if and (eq .Site.Params.invertSectionColors true) (modBool $index_val 2) }} dark{{ end }}'>
             <article id='{{ anchorize $fnav_title }}' class='post {{ if eq $index_val 0 }}first{{ end }} {{ if eq (add $index_val 1) (len $content) }}last{{ end }}'>
                 <header class="post-header">
-                    <h2 class="post-title">{{ .Title | safeHTML }}</h2>
+                    <h2 class="post-title">{{ .Title | emojify | safeHTML }}</h2>
                 </header>
                 <section class="post-content">
                     {{ .Content }}


### PR DESCRIPTION
This pull request aims to add support to markdown emojis in the theme.

With the current version, adding emoticons with the markdown shortcodes ends with them not rendered in the web page. 

![image](https://github.com/zjedi/hugo-scroll/assets/55811966/ba17fa86-b05b-47ce-bb83-84b2e93cdd77)

Adding `enableEmoji = true` in `config.toml` is a starting point but you can't insert emoticons in sections titles because they are rendered separately, thus also the `emojify` function is required (see [docs](https://gohugo.io/functions/transform/emojify/) for further reference) in the `index.html` file. 

With these two updates, the final result is the following:

![image](https://github.com/zjedi/hugo-scroll/assets/55811966/90044a5f-904e-44dc-98ed-e3c51ab81755)
