### PR TITLE
Dedicated page - back button visual fix

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,7 @@
   <main class="content page-template page-{{ .Slug }}">
     <article class="post page">
       <header class="post-header">
-        <a id="blog-logo" href="{{ "" | relLangURL }}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ .Site.Title }}</a>
+        <a id="back-to-main-page" href="{{ "" | relLangURL }}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ .Site.Title }}</a>
       </header>
       <h1 class="post-title">{{ .Title }}</h1>
       <section class="post-content">


### PR DESCRIPTION
Previously, the css of `blog-logo` was applied to the back button on single pages. This led to problems if the title required two lines:

![image](https://github.com/zjedi/hugo-scroll/assets/64665067/79e70e90-83e0-4efb-8c0b-97252cf6a506)

With a unique id this is resolved: 

![image](https://github.com/zjedi/hugo-scroll/assets/64665067/958229dd-f7a4-4ee7-9ad7-ee8ff87bdb60)
