### PR TITLE
Wrap meta information in <HEAD> tags

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}">
-  {{- partial "head.html" . -}}
+  <head>
+    {{- partial "head.html" . -}}
+  </head>
   <body>
     {{- partial "header.html" . -}}
     {{- block "main" . }}{{- end }}


### PR DESCRIPTION
I have a site that uses this theme, and I wanted to verify my ownership of it so I could use Google's search console. Google supplied a custom `meta` tag so I put it into `layouts/partials/custom_head.html`; however, I still failed Google's validation. Then, I realized that the output of `layouts/partials/head.html` is not wrapped in <head></head> tags.

Once I added wrapped the output of head.html in `<head>` and `</head>`, I was able to verify my site.
