### PR TITLE
Add flexibility to index.html to be used in subdirectories

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -1,9 +1,9 @@
 {{ define "main" }}
-{{ $headless := .Site.GetPage "/homepage" }}
+{{ $headless := .GetPage "./homepage" }}
 {{ $sections := $headless.Resources.ByType "page" }}
 {{ $sections := cond .Site.BuildDrafts $sections (where $sections "Draft" "==" false) }}
 {{ $content := where (where $sections "Params.external" "==" nil) "Params.detailed_page_homepage_content" "ne" false }}
-{{ $languages := .Site.Languages }}
+{{ $translations := .Page.AllTranslations }}
 
 <!-- Welcome screen that scrolls out of view -->
 {{ if not .Params.header_use_video }}
@@ -35,17 +35,17 @@
             {{- partial "custom_header_video.html" . -}}
         {{ end }}
 
-	{{ $num_lang := len $languages }}
+	{{ $num_lang := len $translations }}
 	{{ if and (gt $num_lang 1) $.Site.Params.language_menu }}
 	<div id="site-languages" class="inner">
-    {{ range site.Sites }}
-      {{ $lang_title := or .Language.LanguageName (.Language.Lang | strings.ToUpper) }}
-      {{ if eq . $.Site }}
+    {{ range $translations }}
+      {{ $lang_title := or .Language.LanguageName (.Lang | strings.ToUpper) }}
+      {{ if eq .Lang $.Lang }}
         {{ if $.Site.Params.show_current_lang }}
           <span class='btn-lang active'>{{ $lang_title }}</span>
         {{ end }}
       {{ else }}
-        <a class='btn-lang' href='{{ .Home.Permalink }}'>{{ $lang_title }}</a>
+        <a class='btn-lang' href='{{ .RelPermalink }}'>{{ $lang_title }}</a>
       {{ end }}
     {{ end }}
 	</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,9 @@
   <main class="content page-template page-{{ .Slug }}">
     <article class="post page">
       <header class="post-header">
-        <a id="back-to-main-page" href="{{ "" | relLangURL }}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ .Site.Title }}</a>
+        {{ with .Parent }}
+        <a id="back-to-main-page" href="{{ .RelPermalink | relLangURL }}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ or .Title .Site.Title }}</a>
+        {{ end }}
       </header>
       <h1 class="post-title">{{ .Title }}</h1>
       <section class="post-content">


### PR DESCRIPTION
This is a simple PR that does not change the theme's behaviour for existing users in any way (the example page renders exactly the same).

On the other hand, it adds the flexibility of reusing the scrolling `index.html` template in multiple pages (not just the homepage) in a very simple way:
- create `subdir` directory with a `subdir/_index.md` file (i.e. a hugo section)
- Add `layout: index` in `subdir/_index.md` to instruct hugo to use the `_default/index.html` template.
- Place sections in `subdir/homepage/<section>.md` as usual
 
An example can be found in [this commit](https://github.com/chatziko/hugo-scroll/commit/59ded528e4e6bbfaca5747eb98e6a4b4330c9d5f) (not part of the PR).

The changes are straightforward:
- use a relative `./homepage` instead of `/homepage`
- Create a language menu using the translations of the current page (not the whole site)
- Move `index.html` inside `_default` so that it can be re-used.
- Use the `.Parent` page in back links instead of the root page.

I don't know if you'd like to have full support for multiple scrolling pages in the future, or you prefer to keep the theme simple. But in any case this PR is simple and only adds flexibility, so I hope it can be merged.