### PR TITLE
Wrap fork-awesome in <i> instead of <icon>

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -64,7 +64,7 @@
               {{ with .Params.header_menu_title }}{{ $button_title = . }}{{ end }}
 
               {{ if isset .Params "external" }}
-                 <a class='btn site-menu' href='{{ .Params.external | absURL }}'>{{ $button_title }}&nbsp;<icon class="fa fa-external-link"></icon></a>
+                 <a class='btn site-menu' href='{{ .Params.external | absURL }}'>{{ $button_title }}&nbsp;<i class="fa fa-external-link"></i></a>
               {{ else if isset .Params "detailed_page_path" }}
                  <a class='btn site-menu' href='{{ .Params.detailed_page_path | relURL }}'>{{ $button_title }}</a>
               {{ else }}


### PR DESCRIPTION
[W3 validator](https://validator.w3.org/) has an issue with `<icon>` tag inside of `<a>` likely because it's not a known HTML tag. Simply changing to an `<i>` tag removes the error

Work for #195