### PR TITLE
Improve automatic scaling of cover image (fixes blur in mobiles)

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -61,6 +61,9 @@ enableEmoji = true
     # The sections of the home page alternate styling. Mark invert as true to swap the styling of the sections
     invertSectionColors = false
     
+    # Options used for automatic image generation. see: https://gohugo.io/content-management/image-processing/
+    image_options = "webp q90 lanczos photo"
+    
     [params.footer]
     # Show contact icons for email/phone (if specified) in the footer of the page
     showContactIcons = false

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -7,20 +7,45 @@
 
 <!-- Welcome screen that scrolls out of view -->
 {{ if not .Params.header_use_video }}
-{{ with $img := resources.Get .Params.header_image }}
-<style>
-#site-head.withCenteredImage {
-  background-image: url('{{- $img.RelPermalink -}}'); /* Default for larger screens */
-}
-{{ range $size := slice 1280 1024 900 600 360 }}
-{{- with $img.Resize ( printf "%dx lanczos webp photo q100" $size ) -}}
-@media (max-width: {{- printf "%dpx" $size -}}) {
-  #site-head.withCenteredImage { background-image: url('{{- .RelPermalink -}}'); }
-}
-{{ end }}
-{{- end -}}
-</style>
-{{ end }}
+  {{ with $img := resources.Get .Params.header_image }}
+  {{ $image_options := $.Site.Params.image_options | default "webp q90 lanczos photo" -}}
+  <style>
+  /* Default cover for larger screens, converted to webp */
+  {{- with $img.Resize ( printf "%dx%d %s" $img.Width $img.Height $image_options ) -}}
+  #site-head.withCenteredImage {
+    background-image: url('{{- .RelPermalink -}}');
+  }  
+  {{- end -}}
+
+  /*
+  Lower resolutions, uncropped. Aimed at desktop users.
+  We set __both__ max-width and max-height to make sure the image is never upscaled.
+  */
+  {{ range $width := slice 1920 1600 1366 }}
+    {{- with $img.Resize ( printf "%dx %s" $width $image_options ) }}
+    @media (max-width: {{- .Width -}}px) and (max-height: {{- .Height -}}px) {
+      #site-head.withCenteredImage { background-image: url('{{- .RelPermalink -}}'); }
+    }
+    {{- end }}
+  {{- end }}
+
+  /*
+  Lower resolutions, cropped to portrait. Useful for mobile. For "tall" displays (screen ratio < image ratio)
+  the "cover" algorithm first resizes the image to match the screen height, then __crops__ it to match the width.
+  We mimic this by resizing to height=1024, and then cropping to various widths. We set "max-height" to
+  ensure the height is never upscaled, but also max-aspect-ratio to ensure that each image is used in "tall-enough"
+  displays, in which our cropping would happen anyways!
+  */
+  {{- $img_temp := $img.Resize "x1024 q100" -}}/* high quality temporary image, to be cropped later */
+  {{ range $width := slice 900 600 360 }}
+    {{- with $img_temp.Crop ( printf "%dx1024 center %s" $width $image_options ) }}
+    @media (max-height: {{- .Height -}}px) and (max-aspect-ratio: {{ .Width }} / {{ .Height }}) {
+      #site-head.withCenteredImage { background-image: url('{{- .RelPermalink -}}'); }
+    }
+    {{- end }}
+  {{- end }}
+  </style>
+  {{ end }}
 <header id="site-head" class="withCenteredImage">
 {{ else }}
 <header id="site-head">


### PR DESCRIPTION
The current process of generating scaled cover images is problematic, it produces upscaled blurry images on mobile resolutions. Here is a screenshot of the exampleSite on a 412x915 Galaxy Note 20: [screenshot-old](https://github.com/zjedi/hugo-scroll/assets/362089/ba8dbbcc-20ae-44b0-9a6d-7d158e94d03b).

The reason the cover appears blurry is that it uses the following 600x399 scaled version: [cover-scaled-old](https://github.com/zjedi/hugo-scroll/assets/362089/9a7f1754-14ce-4e6c-b514-806befb7d75b), wrapped in a rule:
```
@media (max-width:600px) {
```
Although the image has larger width (600px) that the canvas (412px), its __height__ (399px) is much smaller than the canvas (915px), so the `background-size: cover` algorithm upscales the image to cover the height, leading to the blurry cover.

There are two solutions to this:

1. Include `max-height` in the rule:
   ```
   @media (max-width:600px) and (max-height:399px) {
   ```
   This fixes the issue by simply not picking the scaled version. However the solution is useless for mobile phones which have "tall" aspect ratios, cause none of the scaled images will have sufficient height to be picked.

2. Mimick the `cover` algorithm for tall screens, which first scales the image to fit the height, and then __crops__ it to fit the width. So we can scale to say `height=1024` and the crop to various widths to create portrait versions. For these versions we need a rule with both `max-height`, but also `max-aspect-ratio`, to use them only in "tall" screens in which the original image would be cropped anyway.

This PR implements a combination of both methods. It creates a few "scaled-only" versions of the cover aimed at desktop resolutions. And then a few "scaled-then-cropped" portait versions aimed at mobiles.

In the end the version picked in the 412x915 phone is the following 600x1024 version: [cover-scaled-new](https://github.com/zjedi/hugo-scroll/assets/362089/28bc44a6-74a0-4d3f-9880-73acc5d5c542) , which makes the site look exactly as it would look with the original image: [screenshot-new](https://github.com/zjedi/hugo-scroll/assets/362089/b4958b15-ecd0-4fd2-b241-18264d2eea28).

Two final improvements included in the PR:
- It sets the default quality to `q90` (in my tests it provides much better compression than `q100` at no visible cost), but makes it configurable via the `image_options` param.
- The original large cover is also converted to webp.



