### PR TITLE
Skip the top menu when scrolling on small screens

### DIFF
--- a/assets/css/responsiveness.scss
+++ b/assets/css/responsiveness.scss
@@ -58,6 +58,11 @@
     line-height: 1.6em;
   }
 
+  /* skip the top menu when scrolling */
+  .post-holder .post {
+      scroll-margin-top: 48px;
+  }
+
   .post-template .post {
     padding-bottom: 1rem;
   }


### PR DESCRIPTION
When clicking on a section link on small screens, the section will scroll behind the fixed top menu, which is particularly bad when the top menu is long and wraps in multiple lines.

![image](https://github.com/zjedi/hugo-scroll/assets/362089/4d557214-b5b2-40c3-a35f-8975235b418c)

This PR adds `scroll-margin-top` to compensate for that. Maybe some CSS wizardry could take into accont the exact height of the top menu, but 48px is the height of a single menu line with the default font, and looks ok also for multiple lines.