### PR TITLE
Use css.Sass instead of resources.ToCSS

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,7 +25,7 @@
 {{ $stylesheetFonts := resources.Get "css/fonts.css" }}
 {{ $stylesheetGeneric := resources.Get "css/generic.css" }}
 
-{{ $stylesheetScreen := ( resources.Get "css/_index.scss" | resources.ToCSS ) }}
+{{ $stylesheetScreen := ( resources.Get "css/_index.scss" | css.Sass ) }}
 
 {{ $stylesheet := slice $stylesheetNormalize $stylesheetFA $stylesheetFonts $stylesheetGeneric $stylesheetScreen | resources.Concat "css/style.css" | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $stylesheet.RelPermalink }}" type="text/css" integrity="{{ $stylesheet.Data.Integrity }}" />

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
     publish = "exampleSite/public"
 
 [build.environment]
-    HUGO_VERSION = "0.124.0"
+    HUGO_VERSION = "0.134.2"
     HUGO_THEME = "repo"
 
 [context.production]

--- a/theme.toml
+++ b/theme.toml
@@ -24,7 +24,7 @@ tags = [
   "theme"
 ]
 features = ["cover-image", "favicon", "header-menu", "auto-scroll"]
-min_version = "0.124.0"
+min_version = "0.132.0"
 
 authors = [
   {name = "Jan Raasch", homepage = "https://www.janraasch.com"},


### PR DESCRIPTION
```
WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed
in a future release. Use css.Sass instead.
```