### PR TITLE
Add combine_page_and_site_title option

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -63,6 +63,10 @@ enableEmoji = true
     
     # Options used for automatic image generation. see: https://gohugo.io/content-management/image-processing/
     image_options = "webp q90 lanczos photo"
+
+    # Use "page_title | site_title" for <title> tags
+    # e.g. <title>Legal | Jane Doe - Nutrition Coach & Chef Consultant</title>
+    combine_page_and_site_title = false
     
     [params.footer]
     # Show contact icons for email/phone (if specified) in the footer of the page

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,8 +1,12 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
+{{ if and site.Params.combine_page_and_site_title .Title .Site.Title }}
+<title>{{ .Title | plainify }} | {{ .Site.Title | plainify }}</title>
+{{ else }}
 {{ with or .Title .Site.Title | plainify }}
 <title>{{ . }}</title>
+{{ end }}
 {{ end }}
 
 {{ with resources.Get .Site.Params.favicon }}


### PR DESCRIPTION
If true, it will e.g. change the title tag for the Legal page to 
`<title>Legal | Jane Doe - Nutrition Coach & Chef Consultant</title>`