### PR TITLE
fixing typo which causes build to crash

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,7 @@
 {{ $stylesheetFonts := resources.Get "css/fonts.css" }}
 {{ $stylesheetGeneric := resources.Get "css/generic.css" }}
 
-{{ $stylesheetScreen := ( resources.Get "css/_index.scss" | css.Sass ) }}
+{{ $stylesheetScreen := ( resources.Get "css/_index.scss" | css.scss ) }}
 
 {{ $stylesheet := slice $stylesheetNormalize $stylesheetFA $stylesheetFonts $stylesheetGeneric $stylesheetScreen | resources.Concat "css/style.css" | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $stylesheet.RelPermalink }}" type="text/css" integrity="{{ $stylesheet.Data.Integrity }}" />


### PR DESCRIPTION
As shown - there is a typo in the code which causes the build to crash.

```
ERROR render of "page" failed: "/opt/buildhome/repo/themes/hugo-scroll/layouts/_default/baseof.html:4:8": execute of template failed: template: _default/single.html:4:8: executing "_default/single.html" at <partial "head.html" .>: error calling partial: "/opt/buildhome/repo/themes/hugo-scroll/layouts/partials/head.html:32:60": execute of template failed: template: partials/head.html:32:60: executing "partials/head.html" at <css>: can't evaluate field Sass in type interface {}
```