### PR TITLE
Fix language menu in multihost setting

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -1,9 +1,15 @@
 {{ define "main" }}
 {{ $headless := .GetPage "./homepage" }}
+{{ if hugo.IsMultihost }}
+  {{ $headless := .Site.GetPage "/homepage" }}
+{{ end }}
 {{ $sections := $headless.Resources.ByType "page" }}
 {{ $sections := cond .Site.BuildDrafts $sections (where $sections "Draft" "==" false) }}
 {{ $content := where (where $sections "Params.external" "==" nil) "Params.detailed_page_homepage_content" "ne" false }}
-{{ $translations := .Page.AllTranslations }}
+{{ $langs := .Page.AllTranslations }}
+{{ if hugo.IsMultihost }}
+  {{ $langs = .Site.Languages }}
+{{ end }}
 
 <!-- Welcome screen that scrolls out of view -->
 {{ if not .Params.header_use_video }}
@@ -60,17 +66,26 @@
             {{- partial "custom_header_video.html" . -}}
         {{ end }}
 
-	{{ $num_lang := len $translations }}
-	{{ if and (gt $num_lang 1) $.Site.Params.language_menu }}
+  {{ $num_lang := len $langs }}
+  {{ if and (gt $num_lang 1) $.Site.Params.language_menu }}
 	<div id="site-languages" class="inner">
-    {{ range $translations }}
-      {{ $lang_title := or .Language.LanguageName (.Lang | strings.ToUpper) }}
-      {{ if eq .Lang $.Lang }}
+    {{ range $langs }}
+      {{ $condition := eq .Lang $.Lang }}
+      {{ $lang_func := .Language.LanguageName }}
+      {{ $href := .RelPermalink }}
+      {{ if hugo.IsMultihost }}
+        {{ $langs = site.Sites }}
+        {{ $condition = eq . $.Site }}
+        {{ $lang_func = .LanguageName }}
+        {{ $href = .Home.Permalink }}
+      {{ end }}
+      {{ $lang_title := or $lang_func (.Lang | strings.ToUpper) }}
+      {{ if $condition }}
         {{ if $.Site.Params.show_current_lang }}
           <span class='btn-lang active'>{{ $lang_title }}</span>
         {{ end }}
       {{ else }}
-        <a class='btn-lang' href='{{ .RelPermalink }}'>{{ $lang_title }}</a>
+        <a class='btn-lang' href='{{ $href }}'>{{ $lang_title }}</a>
       {{ end }}
     {{ end }}
 	</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,11 @@
     <article class="post page">
       <header class="post-header">
         {{ with .Parent }}
+          {{ if hugo.IsMultihost }}
+          <a id="back-to-main-page" href="{{ .RelPermalink | relLangURL }}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ or .Title .Site.Title }}</a>
+          {{ else }}
         <a id="back-to-main-page" href="{{ .RelPermalink | relLangURL }}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ or .Title .Site.Title }}</a>
+          {{ end }}
         {{ end }}
       </header>
       <h1 class="post-title">{{ .Title }}</h1>


### PR DESCRIPTION
#196 added the flexibility to index.html to be used in subdirectories.

Unfortunately this broke the language menu in multihost settings. Both functionalities are made to work now by checking the `hugo.IsMultihost` condition.

This makes the code somewhat harder to read, but at least ensures that the regression is fixed.

Fixes: #214