### PR TITLE
Add support for `icon` parameter in front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ If you want to use these branded icons in your contact list, use the full class 
   icon = "fa-brands fa-github"
 ```
 
+You may also use the `icon` parameter in your page frontmatter to set an icon before your title in the section heading, as well as in the header button and nav bar. 
+
+```yaml
+---
+title: "Contact us"
+icon: comments
+header_menu: true
+weight: 6
+---
+```
+
 ### Header logo
 
 Configured in `_index.md`, see `exampleSite`: `header_logo: "images/chef-hat.png"`

--- a/exampleSite/content/de/homepage/contact.md
+++ b/exampleSite/content/de/homepage/contact.md
@@ -1,5 +1,6 @@
 ---
 title: "Contact"
+icon: comments
 weight: 4
 header_menu: true
 ---

--- a/exampleSite/content/en/homepage/contact.md
+++ b/exampleSite/content/en/homepage/contact.md
@@ -1,5 +1,6 @@
 ---
 title: "Contact"
+icon: comments
 weight: 4
 header_menu: true
 ---

--- a/exampleSite/content/en/homepage/services.md
+++ b/exampleSite/content/en/homepage/services.md
@@ -39,6 +39,17 @@ If you want to use these branded icons in your contact list, use the full class 
   icon = "fa-brands fa-github"
 ```
 
+You may also use the `icon` parameter in your page frontmatter to set an icon before your title in the section heading, as well as in the header button and nav bar. 
+
+```yaml
+---
+title: "Contact us"
+icon: comments
+header_menu: true
+weight: 6
+---
+```
+
 ### Nutrition Coaching
 
 This is not an easy task.

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -108,8 +108,13 @@
               {{ else if isset .Params "detailed_page_path" }}
                  <a class='btn site-menu' href='{{ .Params.detailed_page_path | relURL }}'>{{ $button_title }}</a>
               {{ else }}
-                {{ $fnav_title := .Title }}{{ with .Params.navigation_menu_title }}{{ $fnav_title = . }}{{ end }}
-                 <a class='btn site-menu' data-title-anchor='{{ anchorize $fnav_title }}' href='#{{ anchorize $fnav_title }}'>{{ $button_title }}</a>
+                 {{ $fnav_title := .Title }}{{ with .Params.navigation_menu_title }}{{ $fnav_title = . }}{{ end }}
+                 <a class='btn site-menu' data-title-anchor='{{ anchorize $fnav_title }}' href='#{{ anchorize $fnav_title }}'>
+	             {{ with .Params.icon }} 
+                     <i class='fas fa-{{ . }} fa-fw'></i>
+                     {{ end }}
+                     {{ $button_title }}
+		 </a>
               {{ end }}
             {{ end }}
 
@@ -131,7 +136,12 @@
         {{ $last_index_val := 0 }}
         {{ range $index_val, $elem_val := $content }}
             {{ $fnav_title := .Title }}{{ with .Params.navigation_menu_title }}{{ $fnav_title = . }}{{ end }}
-            <a class='fn-item' item_index='{{ (add $index_val 1) }}' href='#{{ anchorize $fnav_title }}'>{{ $fnav_title | safeHTML }}</a>
+            <a class='fn-item' item_index='{{ (add $index_val 1) }}' href='#{{ anchorize $fnav_title }}'>
+		    {{ with .Params.icon }}
+                    <i class='fas fa-{{ . }} fa-fw'></i>
+                    {{ end }}
+                    {{ $fnav_title | safeHTML }}
+	    </a>
             {{ $last_index_val = $index_val }}
         {{ end }}
         {{ if eq .Params.nav_to_top_weight "last" }}
@@ -145,9 +155,13 @@
         {{ if .Title }}
         {{ $fnav_title := .Title }}{{ with .Params.navigation_menu_title }}{{ $fnav_title = . }}{{ end }}
         <div class='post-holder{{ if and (ne .Site.Params.invertSectionColors true) (not (modBool $index_val 2)) }} dark{{ else if and (eq .Site.Params.invertSectionColors true) (modBool $index_val 2) }} dark{{ end }}'>
-            <article id='{{ anchorize $fnav_title }}' class='post {{ if eq $index_val 0 }}first{{ end }} {{ if eq (add $index_val 1) (len $content) }}last{{ end }}'>
-                <header class="post-header">
-                    <h2 class="post-title">{{ .Title | emojify | safeHTML }}</h2>
+            <article id='{{ anchorize $fnav_title }}' class='post {{ if eq $index_val 0 }}first{{ end }} {{ if eq (add $index_val 1) (len $content) }}last{{ end }}'>                <header class="post-header">
+                    <h2 class="post-title">
+			{{ with .Params.icon }}
+                        <i class='fas fa-{{ . }} fa-fw'></i>
+                        {{ end }}
+                        {{ .Title | emojify | safeHTML }}
+		    </h2>
                 </header>
                 <section class="post-content">
                     {{ .Content }}


### PR DESCRIPTION
Adds support for `icon` in front matter to add a Font Awesome icons before the section title in the heading, nav menu and header buttons. Updates README and exampleSite to show usage such as:

```yaml
---
title: "Contact"
icon: comments
weight: 4
header_menu: true
---
```

![IMG_4477](https://github.com/user-attachments/assets/b6b4c2b8-27fd-497a-b37b-04221e4ef377)
![IMG_4478](https://github.com/user-attachments/assets/ddac9d21-878d-4c0b-aef9-d999536e8cf1)
