### PR TITLE
Fix #header-arrow css for high zoom

### DIFF
--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -124,7 +124,7 @@ body {
     font-size: 140px;
     margin: -10px auto;
     text-align: center;
-    position: absolute;
+    display: inline-block;
     width: 100%;
     left: 0;
     bottom: -120px;


### PR DESCRIPTION
Hi there.

I just wanted to make note of a slight issue that can be fixed with the simple change in this pull request.
The problem is that at high-ish zooms (example below is at 150%), the arrow element overlaps the menu, making all clicks on menu buttons lead to the same place: the first part of the page, which the arrow points to.

Have a look at this picture:

![Screenshot_20250508_165606](https://github.com/user-attachments/assets/3483c6eb-8555-4bae-8db3-24791b601de0)

Here my mouse is clearly over the "Links" part of the menu, but as the hover text on bottom left shows, the link is to the `#welcome` part of the page, which is where the arrow leads.

As far as I can tell, this css change fixes the issue, and causes no other problem. In particular, I have tested it on a phone and see no problem, but I might not have thought of all the possible consequences here.

Best regards,

Mark.