### PR TITLE
Replace `.Language.LangName` with `.Language.Label`

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -107,11 +107,11 @@ enableEmoji = true
 [languages]
   [languages.en]
     weight = 10
-    languageName = "English"
+    label = "English"
     contentDir = "content/en"
 
   [languages.de]
     title = "Erika Musterfrau - Ernährungshilfe & Kochberatung"
     weight = 20
     contentDir = "content/de"
-    languageName = "Deutsch"
+    label = "Deutsch"

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -52,10 +52,9 @@
   {{- end }}
   </style>
   {{ end }}
-<header id="site-head" class="withCenteredImage">
-{{ else }}
-<header id="site-head">
 {{ end }}
+
+<header id="site-head" {{ if not .Params.header_use_video }}class="withCenteredImage"{{ end }}>
 
     <div class="vertical">
 

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -71,7 +71,7 @@
 	<div id="site-languages" class="inner">
     {{ range $langs }}
       {{ $condition := eq .Lang $.Lang }}
-      {{ $lang_func := .Language.LanguageName }}
+      {{ $lang_func := .Language.Label }}
       {{ $href := .RelPermalink }}
       {{ if hugo.IsMultihost }}
         {{ $langs = site.Sites }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
     publish = "exampleSite/public"
 
 [build.environment]
-    HUGO_VERSION = "0.134.2"
+    HUGO_VERSION = "0.161.0"
     HUGO_THEME = "repo"
 
 [context.production]


### PR DESCRIPTION
`.Language.LangName` is now deprecated and triggers a warning, but `Language.Label` is an exact replacement.